### PR TITLE
[feature] give option to dump a single message

### DIFF
--- a/include/sns/event.h
+++ b/include/sns/event.h
@@ -76,9 +76,7 @@ struct sns_evhandler {
      *
      * msg is deallocated after handler returns.
      *
-     * Handler should return ACH_OK when everything is fine.  Returning
-     * anything other than ACH_OK will terminate the event loop. The event loop
-     * also terminates if `sns_cx.shutdown=1`.
+     * Handler should return ACH_OK when everything is fine.
      */
     enum ach_status (*handler)(void *context, void *msg, size_t msg_size);
 };
@@ -87,11 +85,13 @@ struct sns_evhandler {
  * Event loop for handling multiple channels.
  *
  * The event loop will return gracefully if the handler returns a status code
- * of ACH_CANCELED. The event loop will terminate the program if it receives any
- * status code other than ACH_CANCELED or ACH_OK.
+ * of ACH_CANCELED. The event loop will terminate the program if the handler
+ * returns any status code other than ACH_CANCELED or ACH_OK. Additionally, the
+ * event loop will terminate the program if ach returns an unrecoverable error
+ * code.
  *
  * The event loop will also return if `sns_cx.shutdown=1` and any channel
- * returns via message timeout or `ach_cancel()`.
+ * returns via message, timeout, or `ach_cancel()`.
  *
  * Finally, the event loop will return if the program receives any signal in
  * `cancel_sigs`.

--- a/include/sns/event.h
+++ b/include/sns/event.h
@@ -84,11 +84,10 @@ struct sns_evhandler {
 /**
  * Event loop for handling multiple channels.
  *
- * The event loop will return gracefully if the handler returns a status code
- * of ACH_CANCELED. The event loop will terminate the program if the handler
- * returns any status code other than ACH_CANCELED or ACH_OK. Additionally, the
- * event loop will terminate the program if ach returns an unrecoverable error
- * code.
+ * Handlers must return status codes ACH_OK or ACH_CANCELED. The event loop
+ * continues if the handler returns ACH_OK and returns if the handler returns
+ * ACH_CANCELED. Additionally, the event loop will terminate the program if ach
+ * returns an unrecoverable error code.
  *
  * The event loop will also return if `sns_cx.shutdown=1` and any channel
  * returns via message, timeout, or `ach_cancel()`.

--- a/src/event.c
+++ b/src/event.c
@@ -78,8 +78,8 @@ static void
 check_evhandle_result(enum ach_status r)
 {
     SNS_REQUIRE(ach_status_match(r, ACH_MASK_OK | ACH_MASK_CANCELED),
-                "asdf Could not handle events: %s, %s\n",
-                ach_result_to_string(r), strerror(errno));
+                "Could not handle event: %s, %s\n", ach_result_to_string(r),
+                strerror(errno));
 }
 enum ach_status ACH_WARN_UNUSED
 sns_evhandle(struct sns_evhandler *handlers, size_t n,

--- a/src/event.c
+++ b/src/event.c
@@ -98,12 +98,11 @@ sns_evhandle(struct sns_evhandler *handlers, size_t n,
         sns_sigcancel(chans, cancel_sigs);
     }
 
-    enum ach_status r = ACH_OK;
     if ((n == 1 && !periodic_handler) || (n == 0 && periodic_handler)) {
         /* special case single channel so we can handle userspace */
         while (!sns_cx.shutdown) {
             errno             = 0;
-            r                 = sns_evhandle_impl(
+            enum ach_status r = sns_evhandle_impl(
                 handlers, handlers->channel, period,
                 handlers->ach_options | ACH_O_RELTIME | ACH_O_WAIT);
             if (sns_cx.shutdown) break;
@@ -125,8 +124,9 @@ sns_evhandle(struct sns_evhandler *handlers, size_t n,
 
         while (!sns_cx.shutdown) {
             errno = 0;
-            r     = ach_evhandle(ach_handlers, n, period, periodic_handler,
-                                 periodic_context, options);
+            enum ach_status r =
+                ach_evhandle(ach_handlers, n, period, periodic_handler,
+                             periodic_context, options);
             if (sns_cx.shutdown) break;
             check_evhandle_result(r);
             if (ach_status_match(r, ACH_MASK_CANCELED)) break;

--- a/src/event.c
+++ b/src/event.c
@@ -57,7 +57,7 @@ sns_evhandle_impl(struct sns_evhandler *cx, ach_channel_t *channel,
         assert(buf);
         r = cx->handler(cx->context, buf, frame_size);
         aa_mem_region_local_pop(buf);
-    } else if (ach_status_match(r, ACH_TIMEOUT | ACH_MASK_STALE_FRAMES)) {
+    } else if (ach_status_match(r, ACH_MASK_TIMEOUT | ACH_MASK_STALE_FRAMES)) {
         assert(NULL == buf);
         r = ACH_OK;
     } else {

--- a/src/snsdump.c
+++ b/src/snsdump.c
@@ -166,6 +166,5 @@ handler(void *cx_, void *msg, size_t msg_size)
     (void)msg_size;
     sns_msg_dump_fun *fun = cx->fun;
     (fun)(stdout, msg);
-    if (cx->run_once) sns_cx.shutdown = 1;
     return cx->run_once ? ACH_CANCELED : ACH_OK;
 }


### PR DESCRIPTION
We query the motor state to get the arm's current position before running any trajectory in Calamity. To that end, its nice to have an option to just return a single message in `snsdump`